### PR TITLE
Fix action not working in windows runner

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,15 +1,25 @@
 const { exec } = require('child_process');
-exec('git describe --tags `git rev-list --tags --max-count=1`', (err, tag, stderr) => {
+exec('git rev-list --tags --max-count=1', (err, rev, stderr) => {
     if (err) {
-        console.log('\x1b[33m%s\x1b[0m', 'Could not find any tags because: ');
+        console.log('\x1b[33m%s\x1b[0m', 'Could not find any revisions because: ');
         console.log('\x1b[31m%s\x1b[0m', stderr);
         process.exit(1);
 
         return;
     }
 
+    exec(`git describe --tags ${rev}`, (err, tag, stderr) => {
+        if (err) {
+            console.log('\x1b[33m%s\x1b[0m', 'Could not find any tags because: ');
+            console.log('\x1b[31m%s\x1b[0m', stderr);
+            process.exit(1);
 
-    console.log('\x1b[32m%s\x1b[0m', `Found tag: ${tag}`);
-    console.log(`::set-output name=tag::${tag}`);
-    process.exit(0);
+            return;
+        }
+
+
+        console.log('\x1b[32m%s\x1b[0m', `Found tag: ${tag}`);
+        console.log(`::set-output name=tag::${tag}`);
+        process.exit(0);
+    });
 });


### PR DESCRIPTION
Running the action on `windows-latest` or `windows-2016` runner gives error:
```
Run WyriHaximus/github-action-get-previous-tag@master
Could not find any tags because: 
error: unknown option `max-count=1`'
usage: git describe [<options>] [<commit-ish>...]
   or: git describe [<options>] --dirty

    --contains            find the tag that comes after the commit
    --debug               debug search strategy on stderr
    --all                 use any ref
    --tags                use any tag, even unannotated
    --long                always use long format
    --first-parent        only follow first parent
    --abbrev[=<n>]        use <n> digits to display SHA-1s
    --exact-match         only output exact matches
    --candidates <n>      consider <n> most recent tags (default: 10)
    --match <pattern>     only consider tags matching <pattern>
    --exclude <pattern>   do not consider tags matching <pattern>
    --always              show abbreviated commit object as fallback
    --dirty[=<mark>]      append <mark> on dirty working tree (default: "-dirty")
    --broken[=<mark>]     append <mark> on broken working tree (default: "-broken")
```
So, it looks like that the backticks are not working under powershell (or is it cmd?). This fix splits the two commands to two separate executions. I've tested this on `ubuntu-latest`, `windows-latest` and `windows-2016`.
