### PR TITLE
Adding `prefix` input to the tag query

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,19 @@ jobs:
           echo "Timestamp: ${{ steps.previoustag.outputs.timestamp }}"
           test -n "${{ steps.previoustag.outputs.tag }}"
           test -n "${{ steps.previoustag.outputs.timestamp }}"
+      - name: Add tag with prefix
+        run: |
+          git tag tag-with-prefix-v1.0.0
+      - name: 'Get Previous tag with prefix'
+        id: previoustagwithprefix
+        uses: ./
+        with:
+          prefix: tag-with-prefix-v
+      - run: |
+          echo "Tag: ${{ steps.previoustagwithprefix.outputs.tag }}"
+          echo "Timestamp: ${{ steps.previoustagwithprefix.outputs.timestamp }}"
+          test -n "${{ steps.previoustagwithprefix.outputs.tag }}"
+          test -n "${{ steps.previoustagwithprefix.outputs.timestamp }}"
       - name: Remove tags
         uses: JesseTG/rm@v1.0.2
         with:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,10 @@ By default, this action will fail if no tag can be found, however, it accepts a 
 tag can be found. Keep in mind that when this action is used in a workflow that has no `.git` directory, it will still 
 fail, and the fallback tag isn't used.
 
+It is also accepts a `prefix` string to query the tags based on it.
+
 * `fallback`: `1.0.0`
+* `prefix`: `tag-prefix`
 
 ## Output
 

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,9 @@ inputs:
   fallback:
     description: 'Fallback tag to use when no previous tag can be found'
     required: false
+  prefix:
+    description: 'Prefix to query the tag by'
+    required: false
 outputs:
   tag:
     description: 'Latest tag'

--- a/main.js
+++ b/main.js
@@ -1,7 +1,8 @@
 const { exec } = require('child_process');
 const fs = require('fs');
+const tagPrefix = `${process.env.INPUT_PREFIX || ''}*`;
 
-exec(`git for-each-ref --sort=-creatordate --count 1 --format="%(refname:short)" "refs/tags/*"`, (err, tag, stderr) => {
+exec(`git for-each-ref --sort=-creatordate --count 1 --format="%(refname:short)" "refs/tags/${tagPrefix}"`, (err, tag, stderr) => {
     tag = tag.trim();
 
     if (err) {


### PR DESCRIPTION
Adding a `prefix` input in order to query tags based on a prefix