### PR TITLE
fetch tags instead of fetch-depth: 0

### DIFF
--- a/examples/scheduled-release.md
+++ b/examples/scheduled-release.md
@@ -16,10 +16,10 @@ jobs:
       previous-tag: ${{ steps.previoustag.outputs.tag }}
       timestamp-diff: ${{ steps.diff.outputs.timestamp-diff }}
     steps:
-      - uses: actions/checkout@v2.3.3
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v4
       #▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼#
+      - run: git fetch --tags origin
+
       - name: Get previous tag
         id: previoustag
         uses: "WyriHaximus/github-action-get-previous-tag@v1"


### PR DESCRIPTION
instead of fetching the whole git history its more efficient to just fetch the tags after checkout.
in repositories with a huge history `fetch-depth: 0` can get pretty slow

see https://github.com/actions/checkout/issues/701#issuecomment-1139627817