### PR TITLE
Fixed a problem with sorting of tags

### DIFF
--- a/main.js
+++ b/main.js
@@ -5,7 +5,7 @@ const workingDirectory = process.env.INPUT_WORKINGDIRECTORY || null;
 
 console.log('\x1b[33m%s\x1b[0m', 'Working directory: ', workingDirectory || '');
 
-exec(`git for-each-ref --sort=-creatordate --count 1 --format="%(refname:short)" "refs/tags/${tagPrefix}"`, {cwd: workingDirectory}, (err, tag, stderr) => {
+exec(`git for-each-ref --sort=-refname --sort=-creatordate --count 1 --format="%(refname:short)" "refs/tags/${tagPrefix}"`, {cwd: workingDirectory}, (err, tag, stderr) => {
     tag = tag.trim();
 
     if (err) {


### PR DESCRIPTION
Fixed a problem where sorting of multiple tags which where created on the same date would not work correctly. Now instead it sorts on the date first and if multiple tags are found on the same date it selects the tag with the "highest" version. For example, earlier if we had two tags with the names: Application-v1.0.0
Application-v1.0.1
Which were created on the same date, the v1.0.0 tag would be selected. Now by also sorting on the refname it will select the tag with the highest version number, i.e Application-v1.0.1 instead.