### PR TITLE
Absolve `prefix` into `pattern`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         id: previoustagwithprefix
         uses: ./
         with:
-          prefix: tag-with-prefix-v
+          pattern: tag-with-prefix-v*
       - run: |
           echo "Tag: ${{ steps.previoustagwithprefix.outputs.tag }}"
           echo "Timestamp: ${{ steps.previoustagwithprefix.outputs.timestamp }}"
@@ -113,7 +113,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - pattern: "v*[0-9].*[0-9].*[0-9]"
+          - pattern: v*[0-9].*[0-9].*[0-9]
             expectedTag: v1.0.1
         pattern:
           - ""

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ GitHub Action that gets the latest tag from Git
 
 By default, this action will fail if no tag can be found, however, it accepts a `fallback` tag that will be used when no 
 tag can be found. Keep in mind that when this action is used in a workflow that has no `.git` directory, it will still 
-fail, and the fallback tag isn't used.  It is also accepts a `prefix` string to query the tags based on it. And finally 
-it takes a `workingDirectory` if you need to look for a tag in an alternative path.
+fail, and the fallback tag isn't used.  It is also accepts a `pattern` string to query the tags based on it. Pattern to 
+query the tag by this can be semver (`v*[0-9].*[0-9].*[0-9]`) or a simple monotonically increasing integer (`r*`) and 
+defaults to * And finally it takes a `workingDirectory` if you need to look for a tag in an alternative path.
 
 * `fallback`: `1.0.0`
-* `prefix`: `tag-prefix`
 * `pattern`: `v*[0-9].*[0-9].*[0-9]`
 * `workingDirectory`: `another/path/where/a/git/repo/is/checked/out`
 

--- a/action.yml
+++ b/action.yml
@@ -1,17 +1,15 @@
-name: 'Get Latest Tag'
-description: 'Get the latest tag from git and outputs that for use in other actions'
+name: Get Latest Tag
+description: Get the latest tag from git and outputs that for use in other actions
 branding:
-  icon: 'tag'
-  color: 'gray-dark'
+  icon: tag
+  color: gray-dark
 inputs:
   fallback:
-    description: 'Fallback tag to use when no previous tag can be found'
-    required: false
-  prefix:
-    description: 'Prefix to query the tag by'
+    description: Fallback tag to use when no previous tag can be found
     required: false
   pattern:
-    description: 'Pattern to query the tag by'
+    description: "Pattern to query the tag by this can be semver (v*[0-9].*[0-9].*[0-9]) or a simple monotonically increasing integer (r*) and defaults to *"
+    default: "*"
     required: false
   workingDirectory:
     description: The directory to run this workflow in
@@ -19,9 +17,9 @@ inputs:
     required: false
 outputs:
   tag:
-    description: 'Latest tag'
+    description: Latest tag
   timestamp:
-    description: 'Latest tag timestamp'
+    description: Latest tag timestamp
 runs:
-  using: 'node20'
-  main: 'main.js'
+  using: node20
+  main: main.js

--- a/main.js
+++ b/main.js
@@ -1,12 +1,11 @@
 const { exec } = require('child_process');
 const fs = require('fs');
-const tagPrefix = `${process.env.INPUT_PREFIX || ''}*`;
-const tagPattern = `${process.env.INPUT_PATTERN || ''}`;
+const tagPattern = `${process.env.INPUT_PATTERN || '*'}`;
 const workingDirectory = process.env.INPUT_WORKINGDIRECTORY || null;
 
 console.log('\x1b[33m%s\x1b[0m', 'Working directory: ', workingDirectory || '');
 
-exec(`git for-each-ref --sort=-refname --sort=-creatordate --count 1 --format="%(refname:short)" "refs/tags/${tagPrefix}${tagPattern}"`, {cwd: workingDirectory}, (err, tag, stderr) => {
+exec(`git for-each-ref --sort=-refname --sort=-creatordate --count 1 --format="%(refname:short)" "refs/tags/${tagPattern}"`, {cwd: workingDirectory}, (err, tag, stderr) => {
     tag = tag.trim();
 
     if (err) {


### PR DESCRIPTION
Since both `prefix` and `pattern` are effectively a glob pattern is makes much more sense to absolve `prefix` into `pattern`.

Migration wise this means migrating from `prefix` to `pattern` going from this:

```yaml
prefix: foo-bar
```

To:

```yaml
pattern: foo-bar*
```