### PR TITLE
Pin WyriHaximus/github-workflows release management to v1.0.1.

### DIFF
--- a/.github/workflows/release-management.yaml
+++ b/.github/workflows/release-management.yaml
@@ -19,7 +19,7 @@ jobs:
   release-managment:
     name: Release Management
     secrets: inherit
-    uses: WyriHaximus/github-workflows/.github/workflows/github-action-release-management.yaml@main
+    uses: WyriHaximus/github-workflows/.github/workflows/github-action-release-management.yaml@89302b3b9ae6ddf2381d9df1669517dd19137332 # v1.0.1
     with:
       milestone: ${{ github.event.milestone.title }}
       description: ${{ github.event.milestone.description }}


### PR DESCRIPTION
Uses the v1.0.1 tag digest instead of floating @main.